### PR TITLE
fix code docblock generation

### DIFF
--- a/src/Generator/Markups/MarkdownMarkup.php
+++ b/src/Generator/Markups/MarkdownMarkup.php
@@ -51,7 +51,7 @@ class MarkdownMarkup implements Markup
      */
     public function block($text)
     {
-        $pattern = '~<(code|pre)>(.+?)</\1>|```php\s(.+?)\n```~s';
+        $pattern = '~<(code|pre)>(.+?)</\1>|```(?:php)?\s(.+?)\n```~s';
         $highlighted = preg_replace_callback($pattern, [$this, 'highlightCb'], $text);
         $text = $this->markdown->transform($highlighted);
         return trim($text);

--- a/src/Templating/Filters/UrlFilters.php
+++ b/src/Templating/Filters/UrlFilters.php
@@ -201,7 +201,7 @@ class UrlFilters extends Filters
         // Merge lines
         $long = preg_replace_callback('~(?:<(code|pre)>.+?</\1>)|([^<]*)~s', function ($matches) {
             return ! empty($matches[2])
-                ? preg_replace('~\n(?:\t|[ ])+~', ' ', $matches[2])
+                ? preg_replace('~\n(?:(\s+\n){2,})+~', ' ', $matches[2])
                 : $matches[0];
         }, $long);
 


### PR DESCRIPTION
fixes https://github.com/cakephp/cakephp-api-docs/issues/64
with additional help from from https://github.com/ApiGen/ApiGen/pull/725 as suggested ADmad

<img width="869" alt="capture d ecran 2016-08-04 a 20 22 14" src="https://cloud.githubusercontent.com/assets/4977112/17413359/361c6af2-5a81-11e6-97a4-3af42e062e8f.png">

I'll work on improving the style to match the book in the cakephp-api-doc repo when this will be in place.
Also let me know if we keep this branch or if you want me to target another one
